### PR TITLE
Performance Increase and Py Compat

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -159,17 +159,17 @@ local function update_signals(entity_data)
     end
 end
 
-
--- TODO: needs better ticking alg (i.e. don't do everything at the same tick)
 local function on_tick (event)
-    if event.tick % settings.global["spoilage-sensor-signal-update-interval"].value == 0 then
-        for k,v in pairs(storage.entity_data) do
+    local tickupdate = event.tick % settings.global["spoilage-sensor-signal-update-interval"].value
+    local tickscan = event.tick % settings.global["spoilage-sensor-signal-scan-interval"].value
+    for k,v in pairs(storage.entity_data) do
+        if tickupdate == ( k % settings.global["spoilage-sensor-signal-update-interval"].value ) then
             update_signals(v)
         end
     end
 
-    if event.tick % settings.global["spoilage-sensor-signal-scan-interval"].value == 1 then
-        for k,v in pairs(storage.entity_data) do
+    for k,v in pairs(storage.entity_data) do
+        if tickscan == ( k % settings.global["spoilage-sensor-signal-scan-interval"].value + 1 ) then
             update_target(v)
         end
     end

--- a/data.lua
+++ b/data.lua
@@ -46,6 +46,14 @@ local combinator_recipe = {
   results = {{type="item", name="spoilage-scanner", amount=1}}
 }
 
+if mods["pyalternativeenergy"] then
+  combinator_recipe.ingredients = {
+    {type = "item", name = "copper-cable", amount = 5},
+    {type = "item", name = "electronic-circuit", amount = 2},
+    {type = "item", name = "battery-mk01", amount = 1}
+  }
+end
+
 table.insert(data.raw["technology"]["advanced-combinators"].effects, { type = "unlock-recipe", recipe = "spoilage-scanner" } )
 
 

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "spoilage-scanner",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "title": "Spoilage Scanner",
   "author": "Krei_",
   "factorio_version": "2.0",


### PR DESCRIPTION
Doing a PR to increase the performance according to your todo comment.
This was done with talks with Krydax after this discussion: https://mods.factorio.com/mod/spoilage-scanner/discussion/67dd659e30915156cf063e88
It now checks still within the setting interval but shifted depending on the entity unit number. 
Tests confirm that the massive spikes that occured with lots of the scanners are barely noticable anymore now.

I also added Py Compat as red circuits are like several hundred hours deep in the modpack, so they require now green circuits and battery just like the other combinators. Would be nice if you could merge this too.