### PR TITLE
Upgrade to Factorio 2.1

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,9 +1,6 @@
 -- control.lua
 
 local flib_gui = require "__flib__.gui"
-local bplib = require("__bplib__.blueprint")
-local BlueprintBuild = bplib.BlueprintBuild
-local BlueprintSetup = bplib.BlueprintSetup
 
 -- NOTE: ghost of destroyed entities have different unit_number than the original entity 
 --   but accessible with ghost_unit_number
@@ -224,38 +221,27 @@ local function on_entity_settings_pasted(event)
     end
 end
 
-local function on_player_setup_blueprint(event)
-    local bp_setup = BlueprintSetup:new(event)
-	if not bp_setup then return end
-
-    local map = bp_setup:map_blueprint_indices_to_world_entities()
-	if not map then return end
-
-    for bp_index, entity in pairs(map) do
-		if entity.name == "spoilage-scanner" then
-            if storage.entity_data[entity.unit_number] then 
-                bp_setup:apply_tags(bp_index, { mode = storage.entity_data[entity.unit_number].mode })
+-- bplib raises this when our entity is extracted into a user blueprint; store our tags.
+local function on_bplib_extract(event)
+    for bp_index, entity in pairs(event.entities) do
+        if entity.name == "spoilage-scanner" then
+            if storage.entity_data[entity.unit_number] then
+                event.blueprint.set_blueprint_entity_tags(bp_index, { mode = storage.entity_data[entity.unit_number].mode })
             end
-		end
-	end
+        end
+    end
 end
 
-local function on_pre_build(event)
-	local bp_build = BlueprintBuild:new(event)
-	if not bp_build then return end
-
-	local overlap_map = bp_build:map_blueprint_indices_to_overlapping_entities(
-		function (bp_entity) return bp_entity.name == "spoilage-scanner" end
-	)
-	if not overlap_map or (not next(overlap_map)) then return end
-
-	local bp_entities = bp_build:get_entities()
-	for bp_index, entity in pairs(overlap_map) do
-		local tags = bp_entities[bp_index].tags or {}
-        if storage.entity_data[entity.unit_number] then 
-            storage.entity_data[entity.unit_number].mode = tags.mode
+-- bplib raises this when a blueprint is stamped over an existing scanner; restore its tags.
+local function on_bplib_overlaps(event)
+    for bp_index, entity in pairs(event.overlaps) do
+        if entity.name == "spoilage-scanner" then
+            local tags = event.blueprint.get_blueprint_entity_tags(bp_index) or {}
+            if storage.entity_data[entity.unit_number] then
+                storage.entity_data[entity.unit_number].mode = tags.mode
+            end
         end
-	end
+    end
 end
 
 
@@ -472,9 +458,9 @@ script.on_event(defines.events.on_space_platform_mined_entity, on_entity_removed
 script.on_event(defines.events.on_entity_died, on_entity_removed, event_filter)
 script.on_event(defines.events.script_raised_destroy, on_entity_removed, event_filter)
 script.on_event(defines.events.on_entity_settings_pasted, on_entity_settings_pasted)
-script.on_event(defines.events.on_player_setup_blueprint, on_player_setup_blueprint)
+script.on_event("bplib-extract", on_bplib_extract)
 script.on_event(defines.events.on_player_rotated_entity, on_entity_rotated)
-script.on_event(defines.events.on_pre_build, on_pre_build)
+script.on_event("bplib-overlaps", on_bplib_overlaps)
 script.on_event(defines.events.on_gui_opened, on_gui_opened)
 script.on_event(defines.events.on_gui_closed, on_gui_closed)
 script.on_event(defines.events.on_tick, on_tick)

--- a/control.lua
+++ b/control.lua
@@ -81,14 +81,14 @@ local function update_signals(entity_data)
     if entity_type == "container" or entity_type == "logistic-container"then
         concat_table(inv, entity_data.target.get_inventory(defines.inventory.chest))
     elseif entity_type == "assembling-machine" then
-        concat_table(inv, entity_data.target.get_inventory(defines.inventory.assembling_machine_input))
-        concat_table(inv, entity_data.target.get_inventory(defines.inventory.assembling_machine_output))
+        concat_table(inv, entity_data.target.get_inventory(defines.inventory.crafter_input))
+        concat_table(inv, entity_data.target.get_inventory(defines.inventory.crafter_output))
         if entity_data.target.burner then
             concat_table(inv, entity_data.target.get_inventory(defines.inventory.fuel))
         end
     elseif entity_type == "furnace" then
-        concat_table(inv, entity_data.target.get_inventory(defines.inventory.furnace_source))
-        concat_table(inv, entity_data.target.get_inventory(defines.inventory.furnace_result))
+        concat_table(inv, entity_data.target.get_inventory(defines.inventory.crafter_input))
+        concat_table(inv, entity_data.target.get_inventory(defines.inventory.crafter_output))
     elseif entity_type == "lab" then
         concat_table(inv, entity_data.target.get_inventory(defines.inventory.lab_input))
     elseif entity_type == "reactor" or entity_type == "boiler" then
@@ -101,7 +101,7 @@ local function update_signals(entity_data)
     elseif entity_type == "cargo-landing-pad" then
         concat_table(inv, entity_data.target.get_inventory(defines.inventory.cargo_landing_pad_main))
     elseif entity_type == "agricultural-tower" then
-        concat_table(inv, entity_data.target.get_inventory(defines.inventory.assembling_machine_output))
+        concat_table(inv, entity_data.target.get_inventory(defines.inventory.crafter_output))
     end
 
     -- calculate freshness

--- a/data.lua
+++ b/data.lua
@@ -63,3 +63,8 @@ data:extend(
     combinator_item,
     combinator_recipe,
   })
+
+-- Register our entity with bplib (2.1 API) so it raises extract/overlap events for it,
+-- letting us persist the scanner's mode through blueprints.
+data.raw["mod-data"]["bplib"].data.extract_entity_names["spoilage-scanner"] = true
+data.raw["mod-data"]["bplib"].data.overlap_entity_names["spoilage-scanner"] = true

--- a/info.json
+++ b/info.json
@@ -4,6 +4,6 @@
   "title": "Spoilage Scanner",
   "author": "Krei_",
   "factorio_version": "2.1",
-  "dependencies": ["base >= 2.0.0", "?space-age", "flib >= 0.16.0", "bplib >= 1.1.6"],
+  "dependencies": ["base >= 2.0.0", "?space-age", "flib >= 0.16.0", "bplib >= 2.1.0"],
   "description": "Adds a spoilage level detector that outputs the freshness level of items inside a container."
 }

--- a/info.json
+++ b/info.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "title": "Spoilage Scanner",
   "author": "Krei_",
-  "factorio_version": "2.0",
+  "factorio_version": "2.1",
   "dependencies": ["base >= 2.0.0", "?space-age", "flib >= 0.16.0", "bplib >= 1.1.6"],
   "description": "Adds a spoilage level detector that outputs the freshness level of items inside a container."
 }


### PR DESCRIPTION
- factorio_version -> 2.1
- replace removed crafter inventory defines: assembling_machine_input / furnace_source -> crafter_input; assembling_machine_output / furnace_result -> crafter_output (incl. agricultural-tower branch)

I'm not sure if this fixes the bug where copy/paste or blueprint build of spoilage scanner wasn't retaining settings but testing that in-game after the migration shows it working correctly so maybe the migration fixed that too.